### PR TITLE
fixed bug that set all feedback to zeros

### DIFF
--- a/python/ah_wrapper/ah_parser.py
+++ b/python/ah_wrapper/ah_parser.py
@@ -15,6 +15,7 @@ class AbstractPacket:
     """
 
     def __init__(self):
+        self.valid = False  # If frame was was properly parsed this becomes true
         self.pos = [0] * 6
         self.vel = [0] * 6
         self.cur = [0] * 6
@@ -77,6 +78,7 @@ class Type1Packet(AbstractPacket):
             self._convert_pos()
             self._convert_cur()
             self._convert_fsr()
+            self.valid = True
         else:
             if config.write_log:
                 logging.warning(f"Bad sized Type 1 Frame: {buffer}")
@@ -118,6 +120,7 @@ class Type2Packet(AbstractPacket):
             self._convert_pos()
             self._convert_vel()
             self._convert_fsr()
+            self.valid = True
         else:
             if config.write_log:
                 logging.warning(f"Bad sized Type 2 Frame: {buffer}")
@@ -152,6 +155,7 @@ class Type3Packet(AbstractPacket):
             self._convert_pos()
             self._convert_vel()
             self._convert_cur()
+            self.valid = True
         else:
             if config.write_log:
                 logging.warning(f"Bad size type 3 frame: {buffer}")

--- a/python/ah_wrapper/ah_serial_client.py
+++ b/python/ah_wrapper/ah_serial_client.py
@@ -172,33 +172,34 @@ class AHSerialClient:
                     if frame:
                         self.n_reads += 1
                         parsed = parse_packet(byte_array=frame)
-                        try:
-                            if type(parsed) == Type3Packet:
-                                self.hand._update_cur(
-                                    positions=parsed.pos,
-                                    velocity=parsed.vel,
-                                    current=parsed.cur,
-                                )
-                            elif type(parsed) == Type2Packet:
-                                self.hand._update_cur(
-                                    positions=parsed.pos,
-                                    velocity=parsed.vel,
-                                    fsr=parsed.fsr,
-                                )
-                            elif type(parsed) == Type1Packet:
-                                self.hand._update_cur(
-                                    positions=parsed.pos,
-                                    current=parsed.cur,
-                                    fsr=parsed.fsr,
-                                )
-                            else:
+                        if parsed is not None and parsed.valid:
+                            try:
+                                if type(parsed) == Type3Packet:
+                                    self.hand._update_cur(
+                                        positions=parsed.pos,
+                                        velocity=parsed.vel,
+                                        current=parsed.cur,
+                                    )
+                                elif type(parsed) == Type2Packet:
+                                    self.hand._update_cur(
+                                        positions=parsed.pos,
+                                        velocity=parsed.vel,
+                                        fsr=parsed.fsr,
+                                    )
+                                elif type(parsed) == Type1Packet:
+                                    self.hand._update_cur(
+                                        positions=parsed.pos,
+                                        current=parsed.cur,
+                                        fsr=parsed.fsr,
+                                    )
+                                else:
+                                    if config.write_log:
+                                        logging.warning(f"Invalid frame {frame}")
+                                        logging.warning(f"Invalid msg {msg}")
+                            except:
                                 if config.write_log:
-                                    logging.warning(f"Invalid frame {frame}")
-                                    logging.warning(f"Invalid msg {msg}")
-                        except:
-                            if config.write_log:
-                                logging.warning(f"Bad frame {frame}")
-                                logging.warning(f"Bad msg {msg}")
+                                    logging.warning(f"Bad frame {frame}")
+                                    logging.warning(f"Bad msg {msg}")
             time.sleep(
                 self._wait_time_s / 2
             )  # Sleeping on the job sometimes good


### PR DESCRIPTION
If a bad sized frame was received but had a valid response type it would reset all of the feedback of that type to zero.  To avoid this added a valid condition to all new frames and then check if the frame is valid before updating feedback.  Yet to be tested thoroughly but could be a very serious bug so would like to leave this public facing for now and circle back to next week.