### PR TITLE
Better Mimic Offsets

### DIFF
--- a/URDF/ability_hand_left_large.urdf
+++ b/URDF/ability_hand_left_large.urdf
@@ -86,7 +86,7 @@
       <child link="index_L1" />
       <origin xyz="0.028 -0.009 0.096" rpy="1.470 -1.317 -1.352" />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -94,13 +94,13 @@
    <joint name="index_q2" type="revolute">
       <parent link="index_L1" />
       <child link="index_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="index_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="index_q1" multiplier="1.05851325" />
    </joint>
    <link name="index_anchor" />
    <joint name="idx_anchor" type="fixed">
@@ -186,7 +186,7 @@
       <parent link="base" />
       <child link="middle_L1" />
       <origin xyz="0.008 -0.012 0.099" rpy="1.629 -1.322 -1.583" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -195,13 +195,13 @@
    <joint name="middle_q2" type="revolute">
       <parent link="middle_L1" />
       <child link="middle_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="middle_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="middle_q1" multiplier="1.05851325" />
    </joint>
    <link name="middle_anchor" />
    <joint name="mid_anchor" type="fixed">
@@ -287,7 +287,7 @@
       <parent link="base" />
       <child link="ring_L1" />
       <origin xyz="-0.012 -0.010 0.097" rpy="1.780 -1.315 -1.811" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -296,13 +296,13 @@
    <joint name="ring_q2" type="revolute">
       <parent link="ring_L1" />
       <child link="ring_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="ring_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="ring_q1" multiplier="1.05851325" />
    </joint>
    <link name="ring_anchor" />
    <joint name="rng_anchor" type="fixed">
@@ -388,7 +388,7 @@
       <parent link="base" />
       <child link="pinky_L1" />
       <origin xyz="-0.031 -0.007 0.091" rpy="1.731 -1.315 -1.828" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -397,13 +397,13 @@
    <joint name="pinky_q2" type="revolute">
       <parent link="pinky_L1" />
       <child link="pinky_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
       <axis xyz="0 0 1" />
-      <mimic joint="pinky_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="pinky_q1" multiplier="1.05851325" />
    </joint>
    <link name="pinky_anchor" />
    <joint name="pnky_anchor" type="fixed">
@@ -500,7 +500,7 @@
       <child link="thumb_L2" />
       <origin xyz="27.8283501e-3 0 -14.7507000e-3" rpy="4.450589592585541 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -545,6 +545,6 @@
    <joint name="fsr29" type="fixed">
       <parent link="thumb_L2" />
       <child link="fsr29" />
-      <origin rrpy="-1.39339 0.19354 -0.40280" xyz="0.05591 0.02160 -0.00192" />
+      <origin rpy="-1.39339 0.19354 -0.40280" xyz="0.05591 0.02160 -0.00192" />
    </joint>
 </robot>

--- a/URDF/ability_hand_left_small.urdf
+++ b/URDF/ability_hand_left_small.urdf
@@ -85,7 +85,7 @@
       <child link="index_L1" />
       <origin xyz="0.028 -0.009 0.096" rpy="1.470 -1.317 -1.352" />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -93,13 +93,13 @@
    <joint name="index_q2" type="revolute">
       <parent link="index_L1" />
       <child link="index_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="index_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="index_q1" multiplier="1.05851325" />
    </joint>
    <link name="index_anchor" />
    <joint name="idx_anchor" type="fixed">
@@ -185,7 +185,7 @@
       <parent link="base" />
       <child link="middle_L1" />
       <origin xyz="0.008 -0.012 0.099" rpy="1.629 -1.322 -1.583" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -194,13 +194,13 @@
    <joint name="middle_q2" type="revolute">
       <parent link="middle_L1" />
       <child link="middle_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="middle_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="middle_q1" multiplier="1.05851325" />
    </joint>
    <link name="middle_anchor" />
    <joint name="mid_anchor" type="fixed">
@@ -286,7 +286,7 @@
       <parent link="base" />
       <child link="ring_L1" />
       <origin xyz="-0.012 -0.010 0.097" rpy="1.780 -1.315 -1.811" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -295,13 +295,13 @@
    <joint name="ring_q2" type="revolute">
       <parent link="ring_L1" />
       <child link="ring_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="ring_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="ring_q1" multiplier="1.05851325" />
    </joint>
    <link name="ring_anchor" />
    <joint name="rng_anchor" type="fixed">
@@ -387,7 +387,7 @@
       <parent link="base" />
       <child link="pinky_L1" />
       <origin xyz="-0.031 -0.007 0.091" rpy="1.731 -1.315 -1.828" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
@@ -396,13 +396,13 @@
    <joint name="pinky_q2" type="revolute">
       <parent link="pinky_L1" />
       <child link="pinky_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
       <axis xyz="0 0 1" />
-      <mimic joint="pinky_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="pinky_q1" multiplier="1.05851325" />
    </joint>
    <link name="pinky_anchor" />
    <joint name="pnky_anchor" type="fixed">
@@ -499,7 +499,7 @@
       <child link="thumb_L2" />
       <origin xyz="27.8283501e-3 0 -14.7507000e-3" rpy="4.450589592585541 0 0" />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->

--- a/URDF/ability_hand_right_large.urdf
+++ b/URDF/ability_hand_right_large.urdf
@@ -85,19 +85,19 @@
       <child link="index_L1" />
       <origin xyz="-2.8e-2 -9e-3 9.6e-2" rpy=" 1.672 -1.317 -1.790 " />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
    </joint>
    <joint name="index_q2" type="revolute">
       <parent link="index_L1" />
       <child link="index_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="index_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="index_q1" multiplier="1.05851325" />
    </joint>
    <link name="index_anchor" />
    <joint name="idx_anchor" type="fixed">
@@ -183,20 +183,20 @@
       <parent link="base" />
       <child link="middle_L1" />
       <origin xyz=" -0.008 -0.012 0.099 " rpy=" 1.513 -1.322 -1.558 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="middle_q2" type="revolute">
       <parent link="middle_L1" />
       <child link="middle_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="middle_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="middle_q1" multiplier="1.05851325" />
    </joint>
    <link name="middle_anchor" />
    <joint name="mid_anchor" type="fixed">
@@ -282,20 +282,20 @@
       <parent link="base" />
       <child link="ring_L1" />
       <origin xyz=" 0.012 -0.010 0.097 " rpy=" 1.361 -1.315 -1.330 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="ring_q2" type="revolute">
       <parent link="ring_L1" />
       <child link="ring_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="ring_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="ring_q1" multiplier="1.05851325" />
    </joint>
    <link name="ring_anchor" />
    <joint name="rng_anchor" type="fixed">
@@ -381,20 +381,20 @@
       <parent link="base" />
       <child link="pinky_L1" />
       <origin xyz=" 0.031 -0.007 0.091 " rpy=" 1.410 -1.315 -1.313 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="pinky_q2" type="revolute">
       <parent link="pinky_L1" />
       <child link="pinky_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
       <axis xyz="0 0 1" />
-      <mimic joint="pinky_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="pinky_q1" multiplier="1.05851325" />
    </joint>
    <link name="pinky_anchor" />
    <joint name="pnky_anchor" type="fixed">
@@ -491,7 +491,7 @@
       <child link="thumb_L2" />
       <origin xyz=" 27.8283501e-3 1.7436510745838653e-19 14.7507e-3 " rpy=" 1.832595714594045 -0.0 5.366520605522463e-18 " />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->

--- a/URDF/ability_hand_right_large_no_fsr.urdf
+++ b/URDF/ability_hand_right_large_no_fsr.urdf
@@ -85,19 +85,19 @@
       <child link="index_L1" />
       <origin xyz="-2.8e-2 -9e-3 9.6e-2" rpy=" 1.672 -1.317 -1.790 " />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
    </joint>
    <joint name="index_q2" type="revolute">
       <parent link="index_L1" />
       <child link="index_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="index_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="index_q1" multiplier="1.05851325" />
    </joint>
    <link name="index_anchor" />
    <joint name="idx_anchor" type="fixed">
@@ -148,20 +148,20 @@
       <parent link="base" />
       <child link="middle_L1" />
       <origin xyz=" -0.008 -0.012 0.099 " rpy=" 1.513 -1.322 -1.558 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="middle_q2" type="revolute">
       <parent link="middle_L1" />
       <child link="middle_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="middle_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="middle_q1" multiplier="1.05851325" />
    </joint>
    <link name="middle_anchor" />
    <joint name="mid_anchor" type="fixed">
@@ -212,20 +212,20 @@
       <parent link="base" />
       <child link="ring_L1" />
       <origin xyz=" 0.012 -0.010 0.097 " rpy=" 1.361 -1.315 -1.330 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="ring_q2" type="revolute">
       <parent link="ring_L1" />
       <child link="ring_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="ring_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="ring_q1" multiplier="1.05851325" />
    </joint>
    <link name="ring_anchor" />
    <joint name="rng_anchor" type="fixed">
@@ -276,20 +276,20 @@
       <parent link="base" />
       <child link="pinky_L1" />
       <origin xyz=" 0.031 -0.007 0.091 " rpy=" 1.410 -1.315 -1.313 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="pinky_q2" type="revolute">
       <parent link="pinky_L1" />
       <child link="pinky_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
       <axis xyz="0 0 1" />
-      <mimic joint="pinky_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="pinky_q1" multiplier="1.05851325" />
    </joint>
    <link name="pinky_anchor" />
    <joint name="pnky_anchor" type="fixed">
@@ -351,7 +351,7 @@
       <child link="thumb_L2" />
       <origin xyz=" 27.8283501e-3 1.7436510745838653e-19 14.7507e-3 " rpy=" 1.832595714594045 -0.0 5.366520605522463e-18 " />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->

--- a/URDF/ability_hand_right_small.urdf
+++ b/URDF/ability_hand_right_small.urdf
@@ -85,19 +85,19 @@
       <child link="index_L1" />
       <origin xyz="-2.8e-2 -9e-3 9.6e-2" rpy=" 1.672 -1.317 -1.790 " />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
    </joint>
    <joint name="index_q2" type="revolute">
       <parent link="index_L1" />
       <child link="index_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000e-3" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="index_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="index_q1" multiplier="1.05851325" />
    </joint>
    <link name="index_anchor" />
    <joint name="idx_anchor" type="fixed">
@@ -183,20 +183,20 @@
       <parent link="base" />
       <child link="middle_L1" />
       <origin xyz=" -0.008 -0.012 0.099 " rpy=" 1.513 -1.322 -1.558 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="middle_q2" type="revolute">
       <parent link="middle_L1" />
       <child link="middle_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="middle_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="middle_q1" multiplier="1.05851325" />
    </joint>
    <link name="middle_anchor" />
    <joint name="mid_anchor" type="fixed">
@@ -282,20 +282,20 @@
       <parent link="base" />
       <child link="ring_L1" />
       <origin xyz=" 0.012 -0.010 0.097 " rpy=" 1.361 -1.315 -1.330 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="ring_q2" type="revolute">
       <parent link="ring_L1" />
       <child link="ring_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
       <axis xyz="0 0 1" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
-      <mimic joint="ring_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="ring_q1" multiplier="1.05851325" />
    </joint>
    <link name="ring_anchor" />
    <joint name="rng_anchor" type="fixed">
@@ -381,20 +381,20 @@
       <parent link="base" />
       <child link="pinky_L1" />
       <origin xyz=" 0.031 -0.007 0.091 " rpy=" 1.410 -1.315 -1.313 " />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <dynamics damping="0.001" friction="0.001" />
       <axis xyz="0 0 1" />
    </joint>
    <joint name="pinky_q2" type="revolute">
       <parent link="pinky_L1" />
       <child link="pinky_L2" />
-      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.084474" />
-      <limit lower="0.766" upper="2.61" effort="6.0" velocity="8.0677777442" />
+      <origin xyz="38.472723e-3 3.257695e-3 0.000000" rpy="0 0 0.766" />
+      <limit lower="0.00" upper="1.844" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->
       <axis xyz="0 0 1" />
-      <mimic joint="pinky_q1" multiplier="1.05851325" offset="0.72349796" />
+      <mimic joint="pinky_q1" multiplier="1.05851325" />
    </joint>
    <link name="pinky_anchor" />
    <joint name="pnky_anchor" type="fixed">
@@ -491,7 +491,7 @@
       <child link="thumb_L2" />
       <origin xyz=" 27.8283501e-3 1.7436510745838653e-19 14.7507e-3 " rpy=" 1.832595714594045 -0.0 5.366520605522463e-18 " />
       <axis xyz="0 0 1" />
-      <limit lower="0" upper="1.74" effort="6.0" velocity="8.0677777442" />
+      <limit lower="0.00" upper="1.74" effort="6.0" velocity="8.0677777442" />
       <!-- angles in rad, efforts in N-m, velocity in rad/s -->
       <dynamics damping="0.001" friction="0.001" />
       <!-- Friction coefficient is not from quantitative measurement -->


### PR DESCRIPTION
The mimic offsets were handled strangely causing many URDF viewers (issac sim included) to start the fingers in an unnatural position then apply the offsets later on.  This ensures they just start in the right position now.