### PR TITLE
Added Port Argument for CPP Linux Connection

### DIFF
--- a/cpp/ah_wrapper/include/linux_serial.h
+++ b/cpp/ah_wrapper/include/linux_serial.h
@@ -1,7 +1,11 @@
 #pragma once
 #include <stdint.h>
 
-int autoconnect_serial(const uint32_t &baud_rate);
+int autoconnect_serial(const uint32_t &baud_rate, const char* port);
 int serial_write(uint8_t *data, uint16_t &size);
 int read_serial(uint8_t *readbuf, uint16_t &bufsize);
 void close_serial(void);
+
+
+// DECLARE filename as such in advance (in case not in /dev/ttyUSB*)
+// char filename[128] = "/dev/ttyACM0";

--- a/cpp/ah_wrapper/include/wrapper.h
+++ b/cpp/ah_wrapper/include/wrapper.h
@@ -19,7 +19,7 @@ class AHWrapper {
 public:
   AHWrapper(const uint8_t &hand_addr, const uint32_t &b_rate);
   ~AHWrapper();
-  int connect();
+  int connect(const char* port);
   int read_write_once(const std::array<float, 6> &cmd_values,
                       const Command &cmd, const uint8_t &reply_mode);
   Hand hand;

--- a/cpp/ah_wrapper/src/linux_serial.cpp
+++ b/cpp/ah_wrapper/src/linux_serial.cpp
@@ -12,10 +12,13 @@
 
 int serial_port = -1;
 char filename[32] = {0}; // some large enough empty buffer
-// DECLARE filename as such in advance (in case not in /dev/ttyUSB*)
-// char filename[128] = "/dev/ttyACM0";
 
-int autoconnect_serial(const uint32_t &BAUD_RATE) {
+int autoconnect_serial(const uint32_t &BAUD_RATE, const char *port) {
+  // If user declared port
+  if (port) {
+    strncpy(filename, port, sizeof(filename) - 1);
+  }
+
   // If user declared filename
   if (filename[0]) {
     serial_port = open(filename, O_RDWR);

--- a/cpp/ah_wrapper/src/wrapper.cpp
+++ b/cpp/ah_wrapper/src/wrapper.cpp
@@ -24,9 +24,9 @@ AHWrapper::~AHWrapper() {
   close_serial();
 }
 
-int AHWrapper::connect() {
+int AHWrapper::connect(const char* port) {
   start_time = std::chrono::steady_clock::now();
-  if (autoconnect_serial(baud_rate)) {
+  if (autoconnect_serial(baud_rate, port)) {
     return 1; // Could not connect
   } else {
     printf("Connected to Hand %d\n", hand.address);

--- a/cpp/hand_wave.cpp
+++ b/cpp/hand_wave.cpp
@@ -7,7 +7,7 @@
 
 int main(int argc, char *argv[]) {
   AHWrapper wrapper = AHWrapper(0x50, 921600);
-  wrapper.connect();
+  wrapper.connect("");
 
   auto now = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration<double>(now.time_since_epoch());

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -5,7 +5,7 @@
 
 int main(int argc, char *argv[]) {
   AHWrapper wrapper = AHWrapper(0x50, 921600);
-  wrapper.connect();
+  wrapper.connect("");
 
   // Send Position Command [0,100]
   std::array<float, 6> cmd = {30.0, 30.0, 30.0, 30.0, 30.0, -30};


### PR DESCRIPTION
The CPP AHWrapper only allowed for auto detection of the RS485 ports, added an argument so you can easily create multiple connections with multiple RS485 adapters.